### PR TITLE
Table filename formatting

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -168,14 +168,24 @@ function markdownReport(reports, commit, options) {
   let output = "";
   for (const report of reports) {
     const folder = reports.length <= 1 ? "" : ` ${report.folder}`;
+    let previousFileFolder;
     for (const file of report.files.filter(
       (file) => filteredFiles == null || filteredFiles.includes(file.filename)
     )) {
       const fileTotal = Math.floor(file.total);
       const fileLines = Math.floor(file.line);
       const fileBranch = Math.floor(file.branch);
+      const fileNameParts = file.filename.split('/');
+      const fileName = fileNameParts.pop();
+      const fileFolder = fileNameParts.join('/');
+      // add unique folder names as rows
+      if (!showClassNames && (fileFolder !== previousFileFolder)) {
+        files.push(fileFolder);
+        previousFileFolder = fileFolder;
+      }
+      // add file details as row
       files.push([
-        escapeMarkdown(showClassNames ? file.name : file.filename),
+        escapeMarkdown(showClassNames ? file.name : fileName),
         `\`${fileTotal}%\``,
         showLine ? `\`${fileLines}%\`` : undefined,
         showBranch ? `\`${fileBranch}%\`` : undefined,
@@ -225,11 +235,14 @@ function markdownReport(reports, commit, options) {
       ...files,
     ]
       .map((row, index) => {
-        return index === 0
-          // heading row
-          ? `<tr><th>${row.filter(Boolean).join('</th><th>')}</th></tr>`
-          // file detail row
-          : `<tr><td>${row.filter(Boolean).join('</td><td align="center">')}</td></tr>`;
+        return Array.isArray(row)
+          ? index === 0
+            // heading row
+            ? `<tr><th>${row.filter(Boolean).join('</th><th>')}</th></tr>`
+            // file detail row
+            : `<tr><td>${row.filter(Boolean).join('</td><td align="center">')}</td></tr>`
+          // folder name row
+          : `</tbody>\n<tbody>\n<tr><td colspan="10" style="border:none;margin-top:2em;">${row}</td></tr>\n</tbody>\n<tbody>`;
       })
       .join("\n");
     const titleText = `<strong>${reportName}${folder}</strong>`;

--- a/src/action.js
+++ b/src/action.js
@@ -215,14 +215,6 @@ function markdownReport(reports, commit, options) {
         showMissing ? "Missing" : undefined,
       ],
       [
-        "-",
-        ":-:",
-        showLine ? ":-:" : undefined,
-        showBranch ? ":-:" : undefined,
-        ":-:",
-        showMissing ? ":-:" : undefined,
-      ],
-      [
         "**All files**",
         `\`${total}%\``,
         showLine ? `\`${linesTotal}%\`` : undefined,
@@ -232,12 +224,16 @@ function markdownReport(reports, commit, options) {
       ],
       ...files,
     ]
-      .map((row) => {
-        return `| ${row.filter(Boolean).join(" | ")} |`;
+      .map((row, index) => {
+        return index === 0
+          // heading row
+          ? `<tr><th>${row.filter(Boolean).join('</th><th>')}</th></tr>`
+          // file detail row
+          : `<tr><td>${row.filter(Boolean).join('</td><td align="center">')}</td></tr>`;
       })
       .join("\n");
     const titleText = `<strong>${reportName}${folder}</strong>`;
-    output += `${titleText}\n\n${table}\n\n`;
+    output += `${titleText}\n\n<table>\n<tbody>\n${table}\n</tbody>\n<table>\n\n`;
   }
   const minimumCoverageText = `_Minimum allowed coverage is \`${minimumCoverage}%\`_`;
   const footerText = `<p align="right">${credits} against ${commit} </p>`;

--- a/src/action.js
+++ b/src/action.js
@@ -246,7 +246,7 @@ function markdownReport(reports, commit, options) {
       })
       .join("\n");
     const titleText = `<strong>${reportName}${folder}</strong>`;
-    output += `${titleText}\n\n<table>\n<tbody>\n${table}\n</tbody>\n<table>\n\n`;
+    output += `${titleText}\n\n<table style="margin-top:2em;">\n<tbody>\n${table}\n</tbody>\n<table>\n\n`;
   }
   const minimumCoverageText = `_Minimum allowed coverage is \`${minimumCoverage}%\`_`;
   const footerText = `<p align="right">${credits} against ${commit} </p>`;

--- a/src/action.js
+++ b/src/action.js
@@ -102,7 +102,7 @@ function formatRangeText([start, end]) {
 }
 
 function tickWrap(string) {
-  return "`" + string + "`";
+  return `<code style="white-space: nowrap;">${string}</code>`;
 }
 
 function cropRangeList(separator, showMissingMaxLength, ranges) {


### PR DESCRIPTION
This PR attempts to format the Coverage Report tables a bit better. To prevent the table requiring a horizontal scrolling action, the table width was reduced by separating out file folder names from filenames. This uses HTML tables instead of markdown tables to give a little more control of the output

Alternatively a much less intrusive PR (keeping file names and table markdown as they are) could be made by allowing the tables to be as wide as they like, but placing them inside a proper horizontally scrollable container (that doesn't squish the content).

note: I haven't run this, so I can't be sure that GitHub will display the table correctly, but from what I understand GitHub will preserve HTML tags as given.

before:
left:
![github com_Kapiche_hypanthium_pull_722(FullHD)](https://user-images.githubusercontent.com/6194521/148315287-51c03a73-7f1c-489c-bbe4-aee22896b06b.png)
scrolled to the right:
![github com_Kapiche_hypanthium_pull_722(FullHD) (1)](https://user-images.githubusercontent.com/6194521/148315305-7b09d62d-123c-4731-9570-9dd3cba0c8de.png)

after:
![github com_Kapiche_hypanthium_pull_722(FullHD) (2)](https://user-images.githubusercontent.com/6194521/148315327-9bd23c10-21a7-4283-83ec-6b89777fde67.png)
