### PR TITLE
Table filename formatting: part 6

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18285,7 +18285,7 @@ function cropRangeList(separator, showMissingMaxLength, ranges) {
 }
 
 function linkRange(fileUrl, range) {
-  const [start, end] = range.split('&NoBreak;').join().slice(1, -1).split("-", 2);
+  const [start, end] = range.replace('&NoBreak;', '').slice(1, -1).split("-", 2);
   const rangeReference = `L${start}` + (end ? `-L${end}` : "");
   // Insert plain=1 to disabled rendered views.
   const url = `${fileUrl}?plain=1#${rangeReference}`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -18265,11 +18265,11 @@ function formatFileUrl(sourceDir, fileName, commit) {
 }
 
 function formatRangeText([start, end]) {
-  return `${start}` + (start === end ? "" : `-${end}`);
+  return `${start}` + (start === end ? "" : `-&NoBreak;${end}`);
 }
 
 function tickWrap(string) {
-  return `<code style="white-space: nowrap;">${string}</code>`;
+  return "`" + string + "`";
 }
 
 function cropRangeList(separator, showMissingMaxLength, ranges) {
@@ -18285,7 +18285,7 @@ function cropRangeList(separator, showMissingMaxLength, ranges) {
 }
 
 function linkRange(fileUrl, range) {
-  const [start, end] = range.slice(1, -1).split("-", 2);
+  const [start, end] = range.split('&NoBreak;').join().slice(1, -1).split("-", 2);
   const rangeReference = `L${start}` + (end ? `-L${end}` : "");
   // Insert plain=1 to disabled rendered views.
   const url = `${fileUrl}?plain=1#${rangeReference}`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -18284,12 +18284,11 @@ function cropRangeList(separator, showMissingMaxLength, ranges) {
   return [ranges, false];
 }
 
-function linkRange(fileUrl, range) {
-  const [start, end] = range.replace('&NoBreak;', '').slice(1, -1).split("-", 2);
+function getRangeURL(fileUrl, range) {
+  const [start, end] = range.split("-", 2);
   const rangeReference = `L${start}` + (end ? `-L${end}` : "");
   // Insert plain=1 to disabled rendered views.
-  const url = `${fileUrl}?plain=1#${rangeReference}`;
-  return `[${range}](${url})`;
+  return `${fileUrl}?plain=1#${rangeReference}`;
 }
 
 function formatMissingLines(
@@ -18307,10 +18306,9 @@ function formatMissingLines(
     showMissingMaxLength,
     formatted
   );
-  const wrapped = cropped.map(tickWrap);
   const linked = showMissingLineLinks
-    ? wrapped.map((range) => linkRange(fileUrl, range))
-    : wrapped;
+    ? cropped.map((range) => `[${tickWrap(range)}](${getRangeURL(fileUrl, range)})`)
+    : cropped.map(tickWrap);
   const joined = linked.join(separator) + (isCropped ? " &hellip;" : "");
   return joined || " ";
 }

--- a/src/action.js
+++ b/src/action.js
@@ -131,7 +131,7 @@ function cropRangeList(separator, showMissingMaxLength, ranges) {
 }
 
 function linkRange(fileUrl, range) {
-  const [start, end] = range.split('&NoBreak;').join().slice(1, -1).split("-", 2);
+  const [start, end] = range.replace('&NoBreak;', '').slice(1, -1).split("-", 2);
   const rangeReference = `L${start}` + (end ? `-L${end}` : "");
   // Insert plain=1 to disabled rendered views.
   const url = `${fileUrl}?plain=1#${rangeReference}`;

--- a/src/action.js
+++ b/src/action.js
@@ -130,12 +130,11 @@ function cropRangeList(separator, showMissingMaxLength, ranges) {
   return [ranges, false];
 }
 
-function linkRange(fileUrl, range) {
-  const [start, end] = range.replace('&NoBreak;', '').slice(1, -1).split("-", 2);
+function getRangeURL(fileUrl, range) {
+  const [start, end] = range.split("-", 2);
   const rangeReference = `L${start}` + (end ? `-L${end}` : "");
   // Insert plain=1 to disabled rendered views.
-  const url = `${fileUrl}?plain=1#${rangeReference}`;
-  return `[${range}](${url})`;
+  return `${fileUrl}?plain=1#${rangeReference}`;
 }
 
 function formatMissingLines(
@@ -153,10 +152,9 @@ function formatMissingLines(
     showMissingMaxLength,
     formatted
   );
-  const wrapped = cropped.map(tickWrap);
   const linked = showMissingLineLinks
-    ? wrapped.map((range) => linkRange(fileUrl, range))
-    : wrapped;
+    ? cropped.map((range) => `[${tickWrap(range)}](${getRangeURL(fileUrl, range)})`)
+    : cropped.map(tickWrap);
   const joined = linked.join(separator) + (isCropped ? " &hellip;" : "");
   return joined || " ";
 }


### PR DESCRIPTION
a few things
- the `dist` appears to have completely changed in 8f6827985950fd9080af0d2e5f95aeaf93b1a8b0, you may be using the wrong version of Node+NPM
- fixed the accidental comma insertion in the hyperlink
- refactored the hyperlink creation to not need to parse out markdown that was just added in