### PR TITLE
Table filename formatting: part 7

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18291,6 +18291,12 @@ function getRangeURL(fileUrl, range) {
   return `${fileUrl}?plain=1#${rangeReference}`;
 }
 
+function linkRange(fileUrl, range) {
+  const url = getRangeURL(fileUrl, range);
+  const text = codeWrap(range);
+  return `<a href="${url}" title="${range}">${text}</a>`
+}
+
 function formatMissingLines(
   fileUrl,
   lineRanges,
@@ -18307,7 +18313,7 @@ function formatMissingLines(
     formatted
   );
   const linked = showMissingLineLinks
-    ? cropped.map((range) => `[${codeWrap(range)}](${getRangeURL(fileUrl, range)})`)
+    ? cropped.map((range) => linkRange(fileUrl, range))
     : cropped.map(codeWrap);
   const joined = linked.join(separator) + (isCropped ? " &hellip;" : "");
   return joined || " ";

--- a/dist/index.js
+++ b/dist/index.js
@@ -18268,8 +18268,8 @@ function formatRangeText([start, end]) {
   return `${start}` + (start === end ? "" : `-&NoBreak;${end}`);
 }
 
-function tickWrap(string) {
-  return "`" + string + "`";
+function codeWrap(string) {
+  return "<code>" + string + "</code>";
 }
 
 function cropRangeList(separator, showMissingMaxLength, ranges) {
@@ -18307,8 +18307,8 @@ function formatMissingLines(
     formatted
   );
   const linked = showMissingLineLinks
-    ? cropped.map((range) => `[${tickWrap(range)}](${getRangeURL(fileUrl, range)})`)
-    : cropped.map(tickWrap);
+    ? cropped.map((range) => `[${codeWrap(range)}](${getRangeURL(fileUrl, range)})`)
+    : cropped.map(codeWrap);
   const joined = linked.join(separator) + (isCropped ? " &hellip;" : "");
   return joined || " ";
 }

--- a/src/action.js
+++ b/src/action.js
@@ -137,6 +137,12 @@ function getRangeURL(fileUrl, range) {
   return `${fileUrl}?plain=1#${rangeReference}`;
 }
 
+function linkRange(fileUrl, range) {
+  const url = getRangeURL(fileUrl, range);
+  const text = codeWrap(range);
+  return `<a href="${url}" title="${range}">${text}</a>`
+}
+
 function formatMissingLines(
   fileUrl,
   lineRanges,
@@ -153,7 +159,7 @@ function formatMissingLines(
     formatted
   );
   const linked = showMissingLineLinks
-    ? cropped.map((range) => `[${codeWrap(range)}](${getRangeURL(fileUrl, range)})`)
+    ? cropped.map((range) => linkRange(fileUrl, range))
     : cropped.map(codeWrap);
   const joined = linked.join(separator) + (isCropped ? " &hellip;" : "");
   return joined || " ";

--- a/src/action.js
+++ b/src/action.js
@@ -114,8 +114,8 @@ function formatRangeText([start, end]) {
   return `${start}` + (start === end ? "" : `-&NoBreak;${end}`);
 }
 
-function tickWrap(string) {
-  return "`" + string + "`";
+function codeWrap(string) {
+  return "<code>" + string + "</code>";
 }
 
 function cropRangeList(separator, showMissingMaxLength, ranges) {
@@ -153,8 +153,8 @@ function formatMissingLines(
     formatted
   );
   const linked = showMissingLineLinks
-    ? cropped.map((range) => `[${tickWrap(range)}](${getRangeURL(fileUrl, range)})`)
-    : cropped.map(tickWrap);
+    ? cropped.map((range) => `[${codeWrap(range)}](${getRangeURL(fileUrl, range)})`)
+    : cropped.map(codeWrap);
   const joined = linked.join(separator) + (isCropped ? " &hellip;" : "");
   return joined || " ";
 }


### PR DESCRIPTION
Attempt to format missing line links using HTML tags instead of markdown when inside of HTML tables