### PR TITLE
Table filename formatting: part 8

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18414,7 +18414,7 @@ function markdownReport(reports, commit, options) {
             // file detail row
             : `<tr><td>${row.filter(Boolean).join('</td><td align="center">')}</td></tr>`
           // folder name row
-          : `</tbody>\n<tbody>\n<tr><td colspan="10"><br/>${row}</td></tr>\n</tbody>\n<tbody>`;
+          : `</tbody>\n<tbody>\n<tr><td colspan="10"><h4>${row}</h4></td></tr>\n</tbody>\n<tbody>`;
       })
       .join("\n")}\n</tbody>\n</table>`;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -18350,6 +18350,8 @@ function markdownReport(reports, commit, options) {
       const fileNameParts = file.filename.split('/');
       const fileName = fileNameParts.pop();
       const fileFolder = fileNameParts.join('/');
+      const fileURL = linkMissingLines ? formatFileUrl(linkMissingLinesSourceDir, file.filename, commit) : '';
+      const fileLink = linkMissingLines ? `<a href="${fileURL}" title="${file.filename}>${fileName}</a>` : '';
       // add unique folder names as rows
       if (!showClassNames && (fileFolder !== previousFileFolder)) {
         files.push(fileFolder);
@@ -18357,14 +18359,14 @@ function markdownReport(reports, commit, options) {
       }
       // add file details as row
       files.push([
-        showClassNames ? file.name : fileName,
+        showClassNames ? file.name : linkMissingLines ? fileLink : fileName,
         `<code>${fileTotal}%</code>`,
         showLine ? `<code>${fileLines}%</code>` : undefined,
         showBranch ? `<code>${fileBranch}%</code>` : undefined,
         status(fileTotal),
         showMissing
           ? file.missing ? formatMissingLines(
-              formatFileUrl(linkMissingLinesSourceDir, file.filename, commit),
+              fileURL,
               file.missing,
               showMissingMaxLength,
               linkMissingLines

--- a/dist/index.js
+++ b/dist/index.js
@@ -18362,13 +18362,13 @@ function markdownReport(reports, commit, options) {
         showLine ? `<code>${fileLines}%</code>` : undefined,
         showBranch ? `<code>${fileBranch}%</code>` : undefined,
         status(fileTotal),
-        showMissing && file.missing
-          ? formatMissingLines(
+        showMissing
+          ? file.missing ? formatMissingLines(
               formatFileUrl(linkMissingLinesSourceDir, file.filename, commit),
               file.missing,
               showMissingMaxLength,
               linkMissingLines
-            )
+            ) : " "
           : undefined,
       ]);
     }

--- a/src/action.js
+++ b/src/action.js
@@ -208,13 +208,13 @@ function markdownReport(reports, commit, options) {
         showLine ? `<code>${fileLines}%</code>` : undefined,
         showBranch ? `<code>${fileBranch}%</code>` : undefined,
         status(fileTotal),
-        showMissing && file.missing
-          ? formatMissingLines(
+        showMissing
+          ? file.missing ? formatMissingLines(
               formatFileUrl(linkMissingLinesSourceDir, file.filename, commit),
               file.missing,
               showMissingMaxLength,
               linkMissingLines
-            )
+            ) : " "
           : undefined,
       ]);
     }

--- a/src/action.js
+++ b/src/action.js
@@ -260,7 +260,7 @@ function markdownReport(reports, commit, options) {
             // file detail row
             : `<tr><td>${row.filter(Boolean).join('</td><td align="center">')}</td></tr>`
           // folder name row
-          : `</tbody>\n<tbody>\n<tr><td colspan="10"><br/>${row}</td></tr>\n</tbody>\n<tbody>`;
+          : `</tbody>\n<tbody>\n<tr><td colspan="10"><h4>${row}</h4></td></tr>\n</tbody>\n<tbody>`;
       })
       .join("\n")}\n</tbody>\n</table>`;
 

--- a/src/action.js
+++ b/src/action.js
@@ -196,6 +196,8 @@ function markdownReport(reports, commit, options) {
       const fileNameParts = file.filename.split('/');
       const fileName = fileNameParts.pop();
       const fileFolder = fileNameParts.join('/');
+      const fileURL = linkMissingLines ? formatFileUrl(linkMissingLinesSourceDir, file.filename, commit) : '';
+      const fileLink = linkMissingLines ? `<a href="${fileURL}" title="${file.filename}>${fileName}</a>` : '';
       // add unique folder names as rows
       if (!showClassNames && (fileFolder !== previousFileFolder)) {
         files.push(fileFolder);
@@ -203,14 +205,14 @@ function markdownReport(reports, commit, options) {
       }
       // add file details as row
       files.push([
-        showClassNames ? file.name : fileName,
+        showClassNames ? file.name : linkMissingLines ? fileLink : fileName,
         `<code>${fileTotal}%</code>`,
         showLine ? `<code>${fileLines}%</code>` : undefined,
         showBranch ? `<code>${fileBranch}%</code>` : undefined,
         status(fileTotal),
         showMissing
           ? file.missing ? formatMissingLines(
-              formatFileUrl(linkMissingLinesSourceDir, file.filename, commit),
+              fileURL,
               file.missing,
               showMissingMaxLength,
               linkMissingLines


### PR DESCRIPTION
more style improvements, maybe
- fix missing cells with 100% file coverage
- try to give greater visual separation between folders and file names (files names now linked)

before:
![Screen Shot 2022-01-07 at 5 23 20 pm](https://user-images.githubusercontent.com/6194521/148507482-c32db856-3b1b-44cd-9769-dcea35e86c26.png)

after:
![Screen Shot 2022-01-07 at 5 23 06 pm](https://user-images.githubusercontent.com/6194521/148507491-fe272903-d069-4264-aba7-7403b8973007.png)

