### PR TITLE
Table filename formatting: part 9

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18351,7 +18351,7 @@ function markdownReport(reports, commit, options) {
       const fileName = fileNameParts.pop();
       const fileFolder = fileNameParts.join('/');
       const fileURL = linkMissingLines ? formatFileUrl(linkMissingLinesSourceDir, file.filename, commit) : '';
-      const fileLink = linkMissingLines ? `<a href="${fileURL}" title="${file.filename}>${fileName}</a>` : '';
+      const fileLink = linkMissingLines ? `<a href="${fileURL}" title="${file.filename}">${fileName}</a>` : '';
       // add unique folder names as rows
       if (!showClassNames && (fileFolder !== previousFileFolder)) {
         files.push(fileFolder);

--- a/src/action.js
+++ b/src/action.js
@@ -197,7 +197,7 @@ function markdownReport(reports, commit, options) {
       const fileName = fileNameParts.pop();
       const fileFolder = fileNameParts.join('/');
       const fileURL = linkMissingLines ? formatFileUrl(linkMissingLinesSourceDir, file.filename, commit) : '';
-      const fileLink = linkMissingLines ? `<a href="${fileURL}" title="${file.filename}>${fileName}</a>` : '';
+      const fileLink = linkMissingLines ? `<a href="${fileURL}" title="${file.filename}">${fileName}</a>` : '';
       // add unique folder names as rows
       if (!showClassNames && (fileFolder !== previousFileFolder)) {
         files.push(fileFolder);


### PR DESCRIPTION
This was unfortunately causing all of the first cell contents to be put into the second cell as a title attribute :/ 