### PR TITLE
Table filename formatting: part 10

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18265,11 +18265,11 @@ function formatFileUrl(sourceDir, fileName, commit) {
 }
 
 function formatRangeText([start, end]) {
-  return `${start}` + (start === end ? "" : `-&NoBreak;${end}`);
+  return `${start}` + (start === end ? "" : `-${end}`);
 }
 
-function codeWrap(string) {
-  return "<code>" + string + "</code>";
+function codeWrapRange(string) {
+  return "<code>" + `${string}`.replace('-', '-&NoBreak;') + "</code>";
 }
 
 function cropRangeList(separator, showMissingMaxLength, ranges) {
@@ -18293,7 +18293,7 @@ function getRangeURL(fileUrl, range) {
 
 function linkRange(fileUrl, range) {
   const url = getRangeURL(fileUrl, range);
-  const text = codeWrap(range);
+  const text = codeWrapRange(range);
   return `<a href="${url}" title="${range}">${text}</a>`
 }
 
@@ -18314,7 +18314,7 @@ function formatMissingLines(
   );
   const linked = showMissingLineLinks
     ? cropped.map((range) => linkRange(fileUrl, range))
-    : cropped.map(codeWrap);
+    : cropped.map((range) => codeWrapRange(range));
   const joined = linked.join(separator) + (isCropped ? " &hellip;" : "");
   return joined || " ";
 }

--- a/src/action.js
+++ b/src/action.js
@@ -111,11 +111,11 @@ function formatFileUrl(sourceDir, fileName, commit) {
 }
 
 function formatRangeText([start, end]) {
-  return `${start}` + (start === end ? "" : `-&NoBreak;${end}`);
+  return `${start}` + (start === end ? "" : `-${end}`);
 }
 
-function codeWrap(string) {
-  return "<code>" + string + "</code>";
+function codeWrapRange(string) {
+  return "<code>" + `${string}`.replace('-', '-&NoBreak;') + "</code>";
 }
 
 function cropRangeList(separator, showMissingMaxLength, ranges) {
@@ -139,7 +139,7 @@ function getRangeURL(fileUrl, range) {
 
 function linkRange(fileUrl, range) {
   const url = getRangeURL(fileUrl, range);
-  const text = codeWrap(range);
+  const text = codeWrapRange(range);
   return `<a href="${url}" title="${range}">${text}</a>`
 }
 
@@ -160,7 +160,7 @@ function formatMissingLines(
   );
   const linked = showMissingLineLinks
     ? cropped.map((range) => linkRange(fileUrl, range))
-    : cropped.map(codeWrap);
+    : cropped.map((range) => codeWrapRange(range));
   const joined = linked.join(separator) + (isCropped ? " &hellip;" : "");
   return joined || " ";
 }


### PR DESCRIPTION
Ensure `&NoBreak;` character isn't added to URL links: only include inside `<code>` blocks

Previously the missing line links includes the HTML character I was using to prevent line breaks
![Screen Shot 2022-01-10 at 4 07 14 pm](https://user-images.githubusercontent.com/6194521/148724510-b0152526-3a69-43d2-8ef1-85dd0828a755.png)

